### PR TITLE
Allow reading AST with ClangTool

### DIFF
--- a/clang/tools/thebesttv/GenAST.h
+++ b/clang/tools/thebesttv/GenAST.h
@@ -13,10 +13,19 @@ class ASTFromFile {
     std::shared_ptr<ASTUnit> AST;
 
   public:
-    ASTFromFile(const std::string &file);
+    /**
+     * 有两种方式读取 AST：
+     * 1. 使用 ClangTool::buildASTs 直接读取。
+     *    这种方法可以获得模板函数的实例化 body，
+     *    但在一些项目中读取时，程序可能直接崩溃。
+     * 2. 先用 clang -emit-ast 生成 AST dump 文件，
+     *    然后用 ASTUnit::LoadFromASTFile 从 dump 中读取 AST。
+     *    这种方法不会导致程序崩溃，但无法获得模板函数的实例化 body。
+     */
+    ASTFromFile(const std::string &file, bool fromASTDump);
 
     ~ASTFromFile() {
-        if (!Global.keepAST) {
+        if (!Global.keepAST && !ASTDumpFile.empty()) {
             // 删除对应的 AST dump 文件
             llvm::sys::fs::remove(ASTDumpFile);
         }

--- a/clang/tools/thebesttv/GenICFG.cpp
+++ b/clang/tools/thebesttv/GenICFG.cpp
@@ -210,7 +210,8 @@ void generateICFG(const CompilationDatabase &cb) {
         // 如果 keepAST 为 true，那很可能磁盘上已经有上一次的 AST dump 了
         //     就算没有，getASTOfFile() 也会重新生成
         // 如果 keepAST 为 false，就保留之前的逻辑，显式调用 generateASTDump()
-        int ret = Global.keepAST ? 0 : generateASTDump(cmd);
+        int ret =
+            (!Global.fromASTDump || Global.keepAST) ? 0 : generateASTDump(cmd);
         if (ret == 0) {
             bool result = updateICFGWithASTDump(cmd.Filename);
             if (result == true) {

--- a/clang/tools/thebesttv/main.cpp
+++ b/clang/tools/thebesttv/main.cpp
@@ -979,6 +979,11 @@ int main(int argc, const char **argv) {
         "DFS tick (timeout checking frequency), default 1'000'000", {"tick"});
     args::ValueFlag<int> argDfsTimeout(
         argParser, "N", "DFS timeout in seconds, default 30", {'t'});
+    args::Flag argFromASTDump(
+        argParser, "from-ast-dump",
+        "Load from AST dump generated with 'clang -emit-ast' "
+        "insted of ClangTool",
+        {"from-ast-dump"});
     args::Flag argKeepAST(argParser, "keep-ast", "Keep AST dumps on disk",
                           {"keep-ast"});
     args::Flag argNoGoodSource(argParser, "no-good-source",
@@ -1025,11 +1030,17 @@ int main(int argc, const char **argv) {
     Global.callDepth = getArgValue(argCallDepth, 6, "Max call depth");
     Global.dfsTick = getArgValue(argDfsTick, 1'000'000, "DFS tick");
     Global.dfsTimeout = getArgValue(argDfsTimeout, 30, "DFS timeout");
+    Global.fromASTDump = getArgValue(argFromASTDump, "From AST dump");
     Global.keepAST = getArgValue(argKeepAST, "Keep AST");
     Global.noGoodSource = getArgValue(argNoGoodSource, "No good-source");
     Global.noNodes = getArgValue(argNoNodes, "No nodes");
     Global.npeFix = getArgValue(argNpeFix, "NPE fix");
     Global.debug = getArgValue(argDebug, "Debug");
+
+    if (!Global.fromASTDump && Global.keepAST) {
+        logger.error("Not reading from AST dump, cannot keep AST");
+        exit(1);
+    }
 
     setClangPath(argv[0]);
 

--- a/clang/tools/thebesttv/utils.h
+++ b/clang/tools/thebesttv/utils.h
@@ -351,6 +351,7 @@ struct GlobalStat {
     int callDepth;
     int dfsTick;
     int dfsTimeout;
+    bool fromASTDump;
     bool keepAST;
     bool noGoodSource;
     bool noNodes;


### PR DESCRIPTION
最开始使用 ClangTool 读取 AST，但在一些项目上会崩溃。
后来从 clang -emit-ast 生成的 dump 读取 AST，但对模板函数支持不完善（实例化后没有body）。
现在默认用 ClangTool，可以在命令行指定用另一种方式读取。

但现在模板函数不需要实例化后的 body，所以这个暂时用不着。