### PR TITLE
Fix: may remove invalidated iterator

### DIFF
--- a/clang/tools/thebesttv/matcher/base.h
+++ b/clang/tools/thebesttv/matcher/base.h
@@ -24,15 +24,19 @@ class BaseMatcher {
     dumpSource(const SourceRange &range,
                const std::optional<SourceRange> &varRange);
 
-    std::optional<typename std::set<ordered_json>::iterator>
+    std::optional<SrcWeakPtr>
     saveSuspectedSource(const SourceRange &range,
                         const std::optional<SourceRange> &varRange,
-                        std::set<ordered_json> &suspectedSources,
+                        SrcSet &suspectedSources, //
                         int n = 100000) {
         auto loc = dumpSource(range, varRange);
         if (!loc)
             return std::nullopt;
-        return reservoirSamplingAddElement(suspectedSources, loc.value(), n);
+        SrcPtr p = std::make_shared<ordered_json>(loc.value());
+        if (reservoirSamplingAddElement(suspectedSources, p, n)) {
+            return p; // 插入成功，则返回对应的 weak_ptr
+        }
+        return std::nullopt;
     }
 
   public:

--- a/clang/tools/thebesttv/matcher/npe.cpp
+++ b/clang/tools/thebesttv/matcher/npe.cpp
@@ -22,7 +22,7 @@ const Expr *NpeSourceMatcher::getProperVar(const Expr *E) {
     return E;
 }
 
-std::optional<typename std::set<ordered_json>::iterator>
+std::optional<SrcWeakPtr> //
 NpeGoodSourceVisitor::saveNpeSuspectedSources(
     const SourceRange &range, const std::optional<SourceRange> &varRange) {
     return saveSuspectedSource(range, varRange, Global.npeSuspectedSources);
@@ -43,7 +43,7 @@ void NpeGoodSourceVisitor::checkFormPEqNullOrFoo(
         if (it) {
             // callee 可能还没被处理过，记录 signature，而不是 fid
             std::string callee = getFullSignature(calleeDecl);
-            Global.npeSuspectedSourcesItMap[callee].push_back(it.value());
+            Global.npeSuspectedSourcesFunMap[callee].push_back(it.value());
         }
     }
 }

--- a/clang/tools/thebesttv/matcher/npe.h
+++ b/clang/tools/thebesttv/matcher/npe.h
@@ -42,7 +42,7 @@ class NpeSourceMatcher : public BaseMatcher {
 class NpeGoodSourceVisitor : public RecursiveASTVisitor<NpeGoodSourceVisitor>,
                              public NpeSourceMatcher {
 
-    std::optional<typename std::set<ordered_json>::iterator>
+    std::optional<SrcWeakPtr>
     saveNpeSuspectedSources(const SourceRange &range,
                             const std::optional<SourceRange> &varRange);
 

--- a/clang/tools/thebesttv/matcher/resourceLeak.h
+++ b/clang/tools/thebesttv/matcher/resourceLeak.h
@@ -37,7 +37,7 @@ class ResourceLeakGoodSourceVisitor
         return false;
     }
 
-    std::optional<typename std::set<ordered_json>::iterator>
+    std::optional<SrcWeakPtr>
     saveSuspectedSource(const SourceRange &range,
                         const std::optional<SourceRange> &varRange) {
         return BaseMatcher::saveSuspectedSource(

--- a/clang/tools/thebesttv/utils.cpp
+++ b/clang/tools/thebesttv/utils.cpp
@@ -319,6 +319,37 @@ int randomInt(int a, int b) {
     return dis(gen);
 }
 
+bool reservoirSamplingAddElement(SrcSet &reservoir, const SrcPtr &element,
+                                 int sampleSize) {
+    // 当前集合大小
+    int currentSize = reservoir.size();
+
+    // 如果当前集合大小小于样本大小，直接将元素添加到集合中
+    if (currentSize < sampleSize) {
+        goto insertElement;
+    } else {
+        // 否则，以概率 sampleSize / currentSize 将元素替换掉集合中的一个元素
+        int replaceIndex = randomInt(0, currentSize - 1);
+        if (replaceIndex >= sampleSize) // 不替换
+            return false;
+
+        // 元素存在，无须插入，这次插入失败
+        if (reservoir.find(element) != reservoir.end())
+            return false;
+
+        // 随机选中一个元素，并将其替换为新元素
+        auto it = reservoir.begin();
+        std::advance(it, replaceIndex);
+        reservoir.erase(it);
+        goto insertElement;
+    }
+    return false;
+
+insertElement:
+    auto p = reservoir.insert(element);
+    return p.second;
+}
+
 /*****************************************************************
  * 以下是没用到的函数
  *****************************************************************/


### PR DESCRIPTION
之前，npeSuspectedSourcesItMap 会记录 npeSuspectedSources 中的部分迭代器。 但 npeSuspectedSources 中的一些元素会在 reservoirSamplingAddElement() 等地方被提前删除。从而导致 npeSuspectedSourcesItMap 中的一部分迭代器
对应之前已经删除的元素，在试图删除这些 invalid iterator 时，发生错误。

修复方法：增加一层 indirection。
- npeSuspectedSources 的元素是 json 的智能指针
- 新的 npeSuspectedSourcesFunMap 中记录这些智能指针的 weak_ptr
  - 使用 weak_ptr 是为了不影响 npeSuspectedSources 中 json 指针的引用数， 确保 npeSuspectedSources 中元素被删除后，可以直接在内存中释放。
- 在删除这些 weak_ptr 时，可以使用 lock() 判断对应的 shared_ptr 是否存在
  - 虽然用不用区别可能不大，毕竟传给 erase() 的已经不再是迭代器了